### PR TITLE
Feature/create invite link

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,6 +82,7 @@ def start(bot_token: str, state_file: str):
     dispatcher.add_handler(MessageHandler(Filters.status_update.new_chat_title, bot.new_chat_title))
     dispatcher.add_handler(MessageHandler(Filters.status_update.chat_created, bot.chat_created))
     dispatcher.add_handler(MessageHandler(Filters.status_update.migrate, bot.migrate_chat_id))
+    dispatcher.add_handler(MessageHandler(Filters.all, bot.noop))
 
     logger.debug(f"Read state from {state_file}")
     if os.path.exists(state_file):

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -550,6 +550,14 @@ class Bot:
         # retry doesn't update the recent changes
         self.update_hhh_message(context.chat_data["chat"], "", retry=True)
 
+    def me(self):
+        return self.updater.bot.get_me()
+
+    @Command()
+    def noop(self, update: Update, context: CallbackContext):
+        self.logger.debug(update)
+        pass
+
 
 def _split_messages(lines):
     message_length = 4096

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -215,7 +215,7 @@ class Bot:
     def delete_message(self, chat_id: str, message_id: str, *args, **kwargs):
         return self.updater.bot.delete_message(chat_id=chat_id, message_id=message_id, *args, **kwargs)
 
-    def update_hhh_message(self, chat: Chat, new_title: str, delete=False, retry=False):
+    def update_hhh_message(self, chat: Chat, new_title: str = "", delete: bool = False, retry: bool = False):
         if not retry:
             latest_change = self.create_latest_change_text(chat, new_title, delete)
             self.logger.debug(f"Add latest change {latest_change} to recent_changes")

--- a/telegram_bot/decorators.py
+++ b/telegram_bot/decorators.py
@@ -71,6 +71,11 @@ class Command:
             if not current_chat.title:
                 log.debug(f"Assign title ({update.effective_chat.title}) to chat ({current_chat}) (previously missing)")
                 current_chat.title = update.effective_chat.title
+            if not current_chat.invite_link and clazz.me().id in [admin.user.id for admin in
+                                                                  current_chat.bot.get_chat_administrators(
+                                                                          chat_id=current_chat.id)]:
+                log.info(f"creating invite link for {current_chat.title}")
+                current_chat.invite_link = update.effective_chat.create_invite_link().invite_link
 
             current_chat.type = update.effective_chat.type
             current_chat.description = update.effective_chat.description

--- a/telegram_bot/decorators.py
+++ b/telegram_bot/decorators.py
@@ -4,6 +4,7 @@ import inspect
 from datetime import timedelta
 
 from telegram import Update
+from telegram.error import BadRequest
 from telegram.ext import CallbackContext
 
 from . import bot
@@ -77,8 +78,12 @@ class Command:
                     and clazz.me().id in [admin.user.id for admin in
                                           current_chat.bot.get_chat_administrators(chat_id=current_chat.id)]:
                 log.info(f"creating invite link for {current_chat.title}")
-                current_chat.invite_link = update.effective_chat.create_invite_link().invite_link
-                clazz.update_hhh_message(current_chat, retry=False)
+                try:
+                    current_chat.invite_link = update.effective_chat.create_invite_link().invite_link
+                    clazz.update_hhh_message(current_chat, retry=False)
+                except BadRequest:
+                    log.exception("failed creating invite link or updating message: ", exc_info=True)
+                    pass
 
             current_chat.type = update.effective_chat.type
             current_chat.description = update.effective_chat.description

--- a/telegram_bot/decorators.py
+++ b/telegram_bot/decorators.py
@@ -76,6 +76,7 @@ class Command:
                                                                           chat_id=current_chat.id)]:
                 log.info(f"creating invite link for {current_chat.title}")
                 current_chat.invite_link = update.effective_chat.create_invite_link().invite_link
+                clazz.update_hhh_message(current_chat, retry=False)
 
             current_chat.type = update.effective_chat.type
             current_chat.description = update.effective_chat.description

--- a/telegram_bot/decorators.py
+++ b/telegram_bot/decorators.py
@@ -71,9 +71,11 @@ class Command:
             if not current_chat.title:
                 log.debug(f"Assign title ({update.effective_chat.title}) to chat ({current_chat}) (previously missing)")
                 current_chat.title = update.effective_chat.title
-            if not current_chat.invite_link and clazz.me().id in [admin.user.id for admin in
-                                                                  current_chat.bot.get_chat_administrators(
-                                                                          chat_id=current_chat.id)]:
+
+            if not current_chat.invite_link \
+                    and current_chat.type != chat.ChatType.PRIVATE and current_chat.type != chat.ChatType.UNDEFINED \
+                    and clazz.me().id in [admin.user.id for admin in
+                                          current_chat.bot.get_chat_administrators(chat_id=current_chat.id)]:
                 log.info(f"creating invite link for {current_chat.title}")
                 current_chat.invite_link = update.effective_chat.create_invite_link().invite_link
                 clazz.update_hhh_message(current_chat, retry=False)


### PR DESCRIPTION
As far as I could see there is no update sent when the bot is promoted to admin, since I don't wanna regularly pull the bot permissions in all chats we have to wait for the next event which is actually detectable via the `Filters`. This is also why there is now a `Filters.all` (registered last) which points to a noop (Bot::noop) method; this way the decorator triggers on every update.

On removing an existing invite link the telegram API actually throws a BadRequest and claims that:

```
telegram.error.BadRequest: Message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message
```

This is only somewhat correct and the message is indeed being updated so that the invite link is removed from the chat-list message.

Closes #52 