### PR TITLE
Remove 'groups' from telegram_bot.bot#Bot/state

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -43,7 +43,6 @@ class Bot:
             "hhh_id": -1001473841450,
             "pinned_message_id": None
         }
-        self.groups = []
         self.state_filepath = state_filepath
 
     def _load_main_admin_ids(self) -> Set[int]:
@@ -72,7 +71,6 @@ class Bot:
 
     def save_state(self) -> None:
         self.state["chats"] = [chat.serialize() for chat in self.chats.values()]
-        self.state["groups"] = self.groups
         with open(self.state_filepath, "w+") as f:
             json.dump(self.state, f)
 


### PR DESCRIPTION
```bash
$ grep -R groups --exclude-dir=venv --exclude=state.json
telegram_bot/bot.py:        :param prefix: Put in front of the constructed text for the groups names
telegram_bot/bot.py:        :param suffix: Put behind of the constructed text for the groups names
telegram_bot/bot.py:        total_group_count_text = f"{len([c for c in self.chats.values() if c.title])} groups in total"
```