### PR TITLE
Change behaviour for changelog creation (`update_hhh_message`)

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -513,8 +513,6 @@ class Bot:
     async def new_chat_title(self, update: Update, context: CallbackContext):
         chat: Chat = context.chat_data["chat"]
         new_title = update.effective_message.new_chat_title
-        if not new_title:
-            self.logger.error("")
 
         return await self.update_hhh_message(chat, new_title=new_title, create_changelog=True)
 


### PR DESCRIPTION
Add new 'create_changelog' flag which is 'False' by default

Update for

- deleted chat
- changed chat title
- new chat

Relates to #115

This also avoids needing the shitty `retry=True` workaround